### PR TITLE
Made work with php 5 and apache2

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,1 @@
+AcceptPathInfo  On

--- a/config.php
+++ b/config.php
@@ -13,23 +13,24 @@
 // Could also use PHP Markdown Extra or PHP Markdown Extra Math
 // Path relative to this config.php file or absolute file path
 
-require '../PhpMarkdownExtra/markdown.php';
+require '../php-markdown-extra-math/markdown.php';
+
 
 // The web path to the document tree root
-$homeWeb = $scriptURL . '/test';
+$homeWeb = $scriptURL . '/test/';
 
 // The file path for the root of your document tree being served by this handler
-$home = $docroot . $homeWeb; // $docroot is the Apache doument DocumentRoot
+$home = $docrootDir . $homeWeb; // $docroot is the Apache doument DocumentRoot
 
 // Main CSS file (URL relative to script folder or starting with / from web root)
 $cssURL = $scriptURL . '/css/main.css';
 
 // Math support
 
-$enableMath = false; // true or false
+$enableMath = true; // true or false
 // MathJax script for math support. Must use PHP Markdown Extra Math (https://github.com/drdrang/php-markdown-extra-math).
 $mathjaxScript = 'https://d3eoax9i5htok0.cloudfront.net/mathjax/latest/MathJax.js?config=TeX-MML-AM_HTMLorMML'; // Use the MathJax site
-$mathjaxConfig = $scriptDir . '/html/mathjaxConfig.html'; // Filename of custom MathJax configuration.
+$mathjaxConfig = $scriptDir . '/mathjaxConfig.html'; // Filename of custom MathJax configuration.
 
 // You could create separate templates for iPhone and iPad if you wanted
 
@@ -45,5 +46,7 @@ else
     {
     $templateHTML = './template.php';
     }
+
+//require 'test.php';
 
 ?>

--- a/doodad.php
+++ b/doodad.php
@@ -1,8 +1,8 @@
 <?php 
 
-// Doodad 1.0
-// Ryan Gray (u2mr2os2@me.com)
-// 16 July 2012
+// Doodad 1.1
+// Lyndon White (oxinabox@ucc.asn.au) 18 jan 2015
+// Ryan Gray (u2mr2os2@me.com)  16 July 2012
 //
 // A handler script for dynamically serving Markdown files.
 //
@@ -221,7 +221,7 @@ $cssURL = $scriptURL . '/css/main.css';
 $crumbOnHome = false;
 $enableMath = false;
 $mathjaxScript = 'https://d3eoax9i5htok0.cloudfront.net/mathjax/latest/MathJax.js?config=TeX-MML-AM_HTMLorMML'; // Use the MathJax site
-$mathjaxConfig = $scriptDir . '/html/mathjaxConfig.html'; // Filename of custom MathJax configuration.
+$mathjaxConfig = $scriptDir . '/mathjaxConfig.html'; // Filename of custom MathJax configuration.
 
 // Synonyms for ?format=source to get the raw Markdown text
 $textFormatAliases = array('md', 'markdown', 'text', 'txt', 'source');
@@ -247,8 +247,11 @@ require 'config.php';
 
 // ----
 
-$mdFile = realpath($_SERVER['PATH_TRANSLATED']);
+//$mdFile = realpath($_SERVER['PATH_TRANSLATED']);
+$mdFile = $docrootDir.$_SERVER['ORIG_PATH_INFO'];
+
 $format = getGetString('format','html');
+//require 'printData.php';
 
 if ($mdFile)
     {

--- a/printData.php
+++ b/printData.php
@@ -1,0 +1,17 @@
+<html>
+<?php
+    echo "hiii<br>";
+    echo "<li>docrootDir ". var_dump($docrootDir);
+    echo "<li>scriptDir ".var_dump($scriptDir);
+    echo "<li>scriptURL ".var_dump($scriptURL);
+    echo "<li>homeWeb ".var_dump($homeWeb);
+    echo "<li>home ".var_dump($home);
+    echo "<li>mdFile ".var_dump($mdFile);
+
+    echo phpinfo();
+?>
+
+</html>
+
+
+

--- a/test/.htaccess
+++ b/test/.htaccess
@@ -5,10 +5,10 @@
 # You can reorder, add or remove index types from this, but you need to include 
 # one for the Markdown file extension(s) you want to use for index files.
 DirectoryIndex index.php index.html index.md index.text 
-
+AcceptPathInfo  On
 # Path for PHP script needs to be from web root, so change this to where you 
 # installed the Doodad folder.
-Action markdown /doodad/doodad.php
+Action markdown /blog/doodad/doodad.php
 
 # Here, you define the Markdown file extensions you want to use.
 # It should include the extensions that you set up for index files.

--- a/test/index.md
+++ b/test/index.md
@@ -5,3 +5,4 @@
 - [Sample](sample)
 
 - [Readme](readme.md)
+


### PR DESCRIPTION
the behaviour of  `$_SERVER['TRANSLATED_PATH']`
has changed.
I made appropriate changes to the code to make it work again

Also I fixed a few typos. (`docroot` vs `docrootDir` in config.php)

Also I made math on by default, cos I like math.
